### PR TITLE
fix: remove method initializeServiceWithAttributes

### DIFF
--- a/src/types/telemetry/telemetryTypes.ts
+++ b/src/types/telemetry/telemetryTypes.ts
@@ -5,7 +5,7 @@
  * For full license text, see LICENSE.txt file in the repo root or https://opensource.org/licenses/BSD-3-Clause
  */
 
-import { ExtensionContext, ExtensionKind, ExtensionMode, Uri } from 'vscode';
+import { ExtensionContext, ExtensionKind, Uri } from 'vscode';
 
 /* eslint-disable header/header */
 /*---------------------------------------------------------
@@ -68,19 +68,6 @@ export interface TelemetryServiceInterface {
    * @param extensionContext extension context
    */
   initializeService(extensionContext: ExtensionContext): Promise<void>;
-  /**
-   * Initialize Telemetry Service with name, apiKey, version, and extensionMode.
-   * @param name extension name
-   * @param apiKey
-   * @param version extension version
-   * @param extensionMode extension mode
-   */
-  initializeServiceWithAttributes(
-    name: string,
-    apiKey?: string,
-    version?: string,
-    extensionMode?: ExtensionMode
-  ): Promise<void>;
 
   /**
    * Helper to get the name for telemetryReporter

--- a/yarn.lock
+++ b/yarn.lock
@@ -324,14 +324,6 @@
     "@commitlint/types" "^19.5.0"
     conventional-changelog-conventionalcommits "^7.0.2"
 
-"@commitlint/config-validator@^19.0.3":
-  version "19.0.3"
-  resolved "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-19.0.3.tgz"
-  integrity sha512-2D3r4PKjoo59zBc2auodrSCaUnCSALCx54yveOFwwP/i2kfEAQrygwOleFWswLqK0UL/F9r07MFi5ev2ohyM4Q==
-  dependencies:
-    "@commitlint/types" "^19.0.3"
-    ajv "^8.11.0"
-
 "@commitlint/config-validator@^19.5.0":
   version "19.5.0"
   resolved "https://registry.yarnpkg.com/@commitlint/config-validator/-/config-validator-19.5.0.tgz#f0a4eda2109fc716ef01bb8831af9b02e3a1e568"
@@ -351,11 +343,6 @@
     lodash.snakecase "^4.1.1"
     lodash.startcase "^4.4.0"
     lodash.upperfirst "^4.3.1"
-
-"@commitlint/execute-rule@^19.0.0":
-  version "19.0.0"
-  resolved "https://registry.npmjs.org/@commitlint/execute-rule/-/execute-rule-19.0.0.tgz"
-  integrity sha512-mtsdpY1qyWgAO/iOK0L6gSGeR7GFcdW7tIjcNFxcWkfLDF5qVbPHKuGATFqRMsxcO8OUKNj0+3WOHB7EHm4Jdw==
 
 "@commitlint/execute-rule@^19.5.0":
   version "19.5.0"
@@ -388,23 +375,7 @@
     "@commitlint/rules" "^19.5.0"
     "@commitlint/types" "^19.5.0"
 
-"@commitlint/load@>6.1.1":
-  version "19.4.0"
-  resolved "https://registry.yarnpkg.com/@commitlint/load/-/load-19.4.0.tgz#7df034e226e300fd577d3f63a72d790d5c821f53"
-  integrity sha512-I4lCWaEZYQJ1y+Y+gdvbGAx9pYPavqZAZ3/7/8BpWh+QjscAn8AjsUpLV2PycBsEx7gupq5gM4BViV9xwTIJuw==
-  dependencies:
-    "@commitlint/config-validator" "^19.0.3"
-    "@commitlint/execute-rule" "^19.0.0"
-    "@commitlint/resolve-extends" "^19.1.0"
-    "@commitlint/types" "^19.0.3"
-    chalk "^5.3.0"
-    cosmiconfig "^9.0.0"
-    cosmiconfig-typescript-loader "^5.0.0"
-    lodash.isplainobject "^4.0.6"
-    lodash.merge "^4.6.2"
-    lodash.uniq "^4.5.0"
-
-"@commitlint/load@^19.5.0":
+"@commitlint/load@>6.1.1", "@commitlint/load@^19.5.0":
   version "19.5.0"
   resolved "https://registry.yarnpkg.com/@commitlint/load/-/load-19.5.0.tgz#67f90a294894d1f99b930b6152bed2df44a81794"
   integrity sha512-INOUhkL/qaKqwcTUvCE8iIUf5XHsEPCLY9looJ/ipzi7jtGhgmtH7OOFiNvwYgH7mA8osUWOUDV8t4E2HAi4xA==
@@ -445,18 +416,6 @@
     minimist "^1.2.8"
     tinyexec "^0.3.0"
 
-"@commitlint/resolve-extends@^19.1.0":
-  version "19.1.0"
-  resolved "https://registry.npmjs.org/@commitlint/resolve-extends/-/resolve-extends-19.1.0.tgz"
-  integrity sha512-z2riI+8G3CET5CPgXJPlzftH+RiWYLMYv4C9tSLdLXdr6pBNimSKukYP9MS27ejmscqCTVA4almdLh0ODD2KYg==
-  dependencies:
-    "@commitlint/config-validator" "^19.0.3"
-    "@commitlint/types" "^19.0.3"
-    global-directory "^4.0.1"
-    import-meta-resolve "^4.0.0"
-    lodash.mergewith "^4.6.2"
-    resolve-from "^5.0.0"
-
 "@commitlint/resolve-extends@^19.5.0":
   version "19.5.0"
   resolved "https://registry.yarnpkg.com/@commitlint/resolve-extends/-/resolve-extends-19.5.0.tgz#f3ec33e12d10df90cae0bfad8e593431fb61b18e"
@@ -491,7 +450,7 @@
   dependencies:
     find-up "^7.0.0"
 
-"@commitlint/types@^19.0.3", "@commitlint/types@^19.5.0":
+"@commitlint/types@^19.5.0":
   version "19.5.0"
   resolved "https://registry.yarnpkg.com/@commitlint/types/-/types-19.5.0.tgz#c5084d1231d4dd50e40bdb656ee7601f691400b3"
   integrity sha512-DSHae2obMSMkAtTBSOulg5X7/z+rGLxcXQIkg3OmWvY6wifojge5uVMydfhUvs7yQj+V7jNmRZ2Xzl8GJyqRgg==


### PR DESCRIPTION
@W-16742418@
telemetry service init must have extensionContext to init properly
Removing the TelemetryServiceInterface method initializeServiceWithAttributes since it cannot safely fetch the extension context when an extension is activating.  