### PR TITLE
feat: add json_schema as parameter to call LLM

### DIFF
--- a/src/types/llmService/LLMService.ts
+++ b/src/types/llmService/LLMService.ts
@@ -28,10 +28,10 @@ export interface LLMServiceInterface {
 export type CallLLMOptions = {
   // Values to be added to the parameters property on the request.
   parameters?: {
-    guided_json?: string;
+    guided_json?: string; // TODO: define the type in detail
   };
   // Properties to be added to the body of the request.
   properties?: {
-    stop_sequence?: string[];
+    stop_sequence?: string[]; // TODO: define the type in detail
   };
 };

--- a/src/types/llmService/LLMService.ts
+++ b/src/types/llmService/LLMService.ts
@@ -12,15 +12,26 @@ export interface LLMServiceInterface {
   /**
    * Calls the LLM with the provided engineered prompt, prompt ID, and input token limit.
    * @param engineeredPrompt - The prompt that has been engineered for the LLM.
-   * @param jsonSchema - The string of the guided json of the structure of the LLM response (optional)
    * @param promptId - The ID of the prompt (optional).
    * @param outputTokenLimit - The limit on the number of output tokens (optional).
+   * @param options - The object of other options in the request (optional)
    * @returns A promise that resolves to the LLM's response as a string.
    */
   callLLM(
     engineeredPrompt: string,
-    jsonSchema?: string,
     promptId?: string,
-    outputTokenLimit?: number
+    outputTokenLimit?: number,
+    options?: CallLLMOptions
   ): Promise<string>;
 }
+
+export type CallLLMOptions = {
+  // Values to be added to the parameters property on the request.
+  parameters?: {
+    guided_json?: string;
+  };
+  // Properties to be added to the body of the request.
+  properties?: {
+    stop_sequence?: string[];
+  };
+};

--- a/src/types/llmService/LLMService.ts
+++ b/src/types/llmService/LLMService.ts
@@ -12,12 +12,14 @@ export interface LLMServiceInterface {
   /**
    * Calls the LLM with the provided engineered prompt, prompt ID, and input token limit.
    * @param engineeredPrompt - The prompt that has been engineered for the LLM.
+   * @param jsonSchema - The string of the guided json of the structure of the LLM response (optional)
    * @param promptId - The ID of the prompt (optional).
    * @param outputTokenLimit - The limit on the number of output tokens (optional).
    * @returns A promise that resolves to the LLM's response as a string.
    */
   callLLM(
     engineeredPrompt: string,
+    jsonSchema?: string,
     promptId?: string,
     outputTokenLimit?: number
   ): Promise<string>;


### PR DESCRIPTION
### What does this PR do?
Add an optional param CallLLMOptions to callLLM function 

### What issues does this PR fix or reference?
@W-17823213@

### Functionality Before
parameters like guided_json and stop_sequence not supported

<insert gif and/or summary>

### Functionality After
parameters like guided_json and stop_sequence supported to callLLM.
<insert gif and/or summary>
