### PR TITLE
W-19136990: Making the interface forwards compatible for telemetry type

### DIFF
--- a/src/types/telemetry/telemetryTypes.ts
+++ b/src/types/telemetry/telemetryTypes.ts
@@ -55,7 +55,7 @@ export type ExtensionsInfo = {
 };
 
 export type ActivationInfo = Partial<ExtensionInfo> & {
-  startActivateHrTime: [number, number];
+  startActivateHrTime: [number, number] | number;
   activateStartDate: Date;
   activateEndDate?: Date;
   extensionActivationTime: number;
@@ -90,7 +90,7 @@ export interface TelemetryServiceInterface {
   sendActivationEventInfo(activationInfo: ActivationInfo): void;
 
   sendExtensionActivationEvent(
-    hrstart: [number, number],
+    hrstart: [number, number] | number,
     markEndTime?: number,
     telemetryData?: TelemetryData
   ): void;
@@ -99,7 +99,7 @@ export interface TelemetryServiceInterface {
 
   sendCommandEvent(
     commandName?: string,
-    hrstart?: [number, number],
+    hrstart?: [number, number] | number,
     properties?: Properties,
     measurements?: Measurements
   ): void;
@@ -114,7 +114,7 @@ export interface TelemetryServiceInterface {
 
   dispose(): void;
 
-  getEndHRTime(hrstart: [number, number]): number;
+  getEndHRTime(hrstart: [number, number] | number): number;
 
-  hrTimeToMilliseconds(hrtime: [number, number]): number;
+  hrTimeToMilliseconds(hrtime: [number, number] | number): number;
 }


### PR DESCRIPTION
### What does this PR do?
Adds forward compatibility for the telemetry interface 

### What issues does this PR fix or reference?

@W-19136990@

### Functionality Before
only accepted [number, number] as time inputs

### Functionality After
accepts number AND [number, number] which means it's forwards and backwards compatible with our new implementation 
