### PR TITLE
W-23832274: Configure Yarn for shared workflows

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -7,4 +7,7 @@ on:
 jobs:
   automerge:
     uses: salesforcecli/github-workflows/.github/workflows/automerge.yml@main
+    with:
+      package-manager: yarn
+      cache-dependency-path: yarn.lock
     secrets: inherit

--- a/.github/workflows/onRelease.yml
+++ b/.github/workflows/onRelease.yml
@@ -29,5 +29,7 @@ jobs:
       ctc: false
       tag: ${{ needs.getDistTag.outputs.tag || 'latest' }}
       githubTag: ${{ github.event.release.tag_name || inputs.tag }}
+      packageManager: yarn
+      cacheDependencyPath: yarn.lock
 
     secrets: inherit


### PR DESCRIPTION
### What does this PR do?

Explicitly configures the shared automerge and npm publish workflows to use Yarn and `yarn.lock`.

### What issues does this PR fix or reference?

@W-23832274@

### Functionality Before

The updated automerge workflow defaulted to npm and attempted to cache dependencies using a missing `package-lock.json`, causing scheduled automerge runs to fail.

### Functionality After

Package-aware shared workflow jobs explicitly use Yarn and the repository's `yarn.lock`.

### Validation

- TypeScript build passed
- Jest: 16 tests passed
- YAML parsing passed
- `git diff --check` passed